### PR TITLE
feat: Add alternate remote logic

### DIFF
--- a/cmd/account.go
+++ b/cmd/account.go
@@ -22,6 +22,7 @@ const (
 	ACCOUNT_GROUP  = "account"
 	ACCOUNT_REGION = "region"
 	ACCOUNT_ID     = "id"
+	ACCOUNT_URL    = "url"
 	ROLE_ARN_KEY   = "role_arn"
 )
 
@@ -183,6 +184,16 @@ func getAccountID(profile string) string {
 		log.Printf("couldn't find an account ID matching profile %s, using empty default...\n", profile)
 	}
 	return id
+}
+
+func getAccountURL(profile string) string {
+	url := viper.GetString(fmt.Sprintf("%s.%s.%s", ACCOUNT_GROUP, profile, ACCOUNT_URL))
+	if url == "" {
+		log.Printf("couldn't find an account URL matching profile %s, using core default...\n", url)
+	} else {
+		return url
+	}
+	return viper.GetString(lenv.CORE_URL)
 }
 
 func getAccountRegion(profile string) string {

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -31,6 +31,7 @@ var (
 	accountRegion  string
 	accountToken   string
 	accountPrivate bool
+	accountURL     string
 	allAccounts    bool
 
 	ErrNoAccountFound = errors.New("no account found")
@@ -39,9 +40,10 @@ var (
 
 type Account struct {
 	ID      string
-	Region  string
 	Private bool
+	Region  string
 	Token   string
+	URL     string
 }
 
 // accountCmd represents the account command
@@ -73,6 +75,7 @@ var accountAddCmd = &cobra.Command{
 			Region:  accountRegion,
 			Private: accountPrivate,
 			Token:   accountToken,
+			URL:     accountURL,
 		})
 		if err != nil {
 			log.Fatal("couldn't write to configuration file:", err)
@@ -112,6 +115,7 @@ var accountSetCmd = &cobra.Command{
 			Region:  accountRegion,
 			Private: accountPrivate,
 			Token:   accountToken,
+			URL:     accountURL,
 		})
 		err := viper.WriteConfig()
 		if err != nil {
@@ -145,6 +149,7 @@ func init() {
 
 	accountAddCmd.Flags().StringVarP(&accountRegion, "region", "r", "", "The default region to associate to the account")
 	accountAddCmd.Flags().StringVarP(&accountToken, "token", "t", "default", "The token to use for the account")
+	accountAddCmd.Flags().StringVar(&accountURL, "url", viper.GetString(lenv.CORE_URL), "The SSO URL to use for the account")
 	accountAddCmd.Flags().BoolVarP(&accountPrivate, "private", "p", false, "The account is a private account")
 	accountAddCmd.Flags().StringVar(&accountName, "name", "", "The logical name of the account being added")
 	if err := accountAddCmd.MarkFlagRequired("name"); err != nil {
@@ -158,6 +163,7 @@ func init() {
 	accountSetCmd.Flags().StringVarP(&accountRegion, "region", "r", "", "The default region to associate to the account")
 	accountSetCmd.Flags().StringVar(&accountNumber, "number", "", "The account number of the account associated to the account name")
 	accountSetCmd.Flags().StringVarP(&accountToken, "token", "t", "default", "The token to use for the account")
+	accountSetCmd.Flags().StringVar(&accountURL, "url", viper.GetString(lenv.CORE_URL), "The SSO URL to use for the account")
 	accountSetCmd.Flags().BoolVarP(&accountPrivate, "private", "p", false, "The account is a private account")
 }
 
@@ -230,9 +236,16 @@ func listAccounts(all bool) {
 			t = account.Token
 		}
 
+		var url string
+		if account.URL == "" {
+			url = "(default) " + viper.GetString(lenv.CORE_URL)
+		} else {
+			url = account.URL
+		}
+
 		if err == nil {
-			fmt.Printf("%s:\n  ID: %s\n  Region: %s\n  Private: %t\n  Token: %s\n",
-				a, account.ID, account.Region, account.Private, t)
+			fmt.Printf("%s:\n  ID: %s\n  Region: %s\n  Private: %t\n  Token: %s\n  SSO URL: %s\n",
+				a, account.ID, account.Region, account.Private, t, url)
 		}
 	}
 

--- a/pkg/v1/aws/oidc.go
+++ b/pkg/v1/aws/oidc.go
@@ -138,11 +138,13 @@ func RegisterClient(ctx context.Context, cfg *aws.Config, startUrl string, b bro
 		ClientType: aws.String(clientType),
 	})
 	if err != nil {
+		log.Println("could not register a new OIDC client")
 		return nil, err
 	}
 
 	output, err := StartDeviceAuthorization(ctx, cfg, startUrl, resp)
 	if err != nil {
+		log.Println("could not start device authorization")
 		return nil, err
 	}
 


### PR DESCRIPTION
This is a brute-force addition of an additional URL during the account auth process.... realizing that this project needs a big upgrade in order to make it a bit more modular... assumptions were made, but this is definitely tailored to only my use-case